### PR TITLE
Move frame processing to CPU before uint8 conversion to support longer video generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,5 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+checkpoints/

--- a/nodes.py
+++ b/nodes.py
@@ -459,10 +459,12 @@ class LatentSyncNode:
                 frames = torch.stack(images).to(device)
             else:
                 frames = images.to(device)
-            frames = (frames * 255).byte()
+ 
+            frames_cpu = frames.cpu()  
+            del frames  
+            torch.cuda.empty_cache()  
 
-            if len(frames.shape) == 3:
-                frames = frames.unsqueeze(0)
+            frames = (frames_cpu * 255).to(torch.uint8)
 
             # Process audio with device awareness
             waveform = audio["waveform"].to(device)


### PR DESCRIPTION
To avoid GPU memory allocation issues, frames are now moved to CPU before uint8 conversion. This change enables generation of longer videos without OOM errors.
