### PR TITLE
Fix InsightFace model root and fully offload frame stacking to CPU

### DIFF
--- a/latentsync/utils/face_detector.py
+++ b/latentsync/utils/face_detector.py
@@ -2,14 +2,19 @@ from insightface.app import FaceAnalysis
 import numpy as np
 import torch
 
+
 INSIGHTFACE_DETECT_SIZE = 640
 
+import os
 
 class FaceDetector:
     def __init__(self, device="cuda"):
+        wrapper_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        model_root   = os.path.join(wrapper_root, "checkpoints", "auxiliary")
+        
         self.app = FaceAnalysis(
             allowed_modules=["detection", "landmark_2d_106"],
-            root="checkpoints/auxiliary",
+            root=str(model_root),
             providers=["CUDAExecutionProvider"],
         )
         self.app.prepare(ctx_id=cuda_to_int(device), det_size=(INSIGHTFACE_DETECT_SIZE, INSIGHTFACE_DETECT_SIZE))

--- a/nodes.py
+++ b/nodes.py
@@ -455,14 +455,13 @@ class LatentSyncNode:
             cur_dir = os.path.dirname(os.path.abspath(__file__))
             
             # Process input frames
+           # Process input frames entirely on CPU to avoid GPU OOM
             if isinstance(images, list):
-                frames = torch.stack(images).to(device)
+                frames_cpu = torch.stack(images)   # CPU tensor
             else:
-                frames = images.to(device)
- 
-            frames_cpu = frames.cpu()  
-            del frames  
-            torch.cuda.empty_cache()  
+                frames_cpu = images.detach().cpu()
+
+            torch.cuda.empty_cache()
 
             frames = (frames_cpu * 255).to(torch.uint8)
 


### PR DESCRIPTION

This PR fixes two issues:

1. **Correct InsightFace model root**  
   - In `latentsync/utils/face_detector.py`, compute the repository root via `os.path.dirname(...)`  
   - Point `FaceAnalysis(..., root=...)` at `${REPO_ROOT}/checkpoints/auxiliary`  


2. **Fully offload frame stacking to CPU**  
   - In `nodes.py`’s `inference()` method, stack and convert input `images` on CPU only:
     ```python
     frames_cpu = torch.stack(images)       # or images.detach().cpu()
     torch.cuda.empty_cache()
     frames = (frames_cpu * 255).to(torch.uint8)
     ```  
   - Removes any `.to(device)` on the full batch of frames  
   - Keeps GPU memory reserved for the model itself, preventing OOM on lower-VRAM cards
